### PR TITLE
Slurm accounting database and REST API checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ The suite can then be launched from the login node with:
 ```shell
 git clone https://github.com/charmed-hpc/charmed-hpc-benchmarks
 cd charmed-hpc-benchmarks
-reframe -C config/azure_config.py -c checks -r -R
+reframe -C config/azure_config.py -c checks -r -R -S slurmrestd_api_check.slurmrestd_hostname=juju-50c1e0-2
 ```
+
+substituting `slurmrestd_hostname=juju-50c1e0-2` with the instance ID for `slurmrestd` in your setup.
 
 ## 🤔 What's next?
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The suite can then be launched from the login node with:
 ```shell
 git clone https://github.com/charmed-hpc/charmed-hpc-benchmarks
 cd charmed-hpc-benchmarks
-reframe -C config/azure_config.py -c checks -r -R -S slurmrestd_api_check.slurmrestd_hostname=juju-50c1e0-2
+reframe --config-file config/azure_config.py --checkpath checks --recursive --run --setvar slurmrestd_api_check.slurmrestd_hostname=juju-50c1e0-2
 ```
 
 substituting `slurmrestd_hostname=juju-50c1e0-2` with the instance ID for `slurmrestd` in your setup.

--- a/checks/slurm/slurmdbd/slurmdbd.py
+++ b/checks/slurm/slurmdbd/slurmdbd.py
@@ -1,0 +1,43 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Checks for Slurm accounting database health."""
+
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+REFERENCE = {
+    "azure:login": {"real_time": (0.2, None, 0.1, "s")},
+}
+
+
+@rfm.simple_test
+class slurmrmdbd_check(rfm.RunOnlyRegressionTest):
+    """Slurm accounting database health check."""
+
+    valid_systems = ["*:login"]
+    valid_prog_environs = ["builtin"]
+    reference = REFERENCE
+
+    @run_before("run")
+    def set_run_commands(self):
+        """Set job script commands."""
+        # Use `sacct` to check responsiveness of accounting database from all valid_systems.
+        # Latency is measured using `time`.
+        self.executable = "time"
+        self.executable_opts = [
+            "-p",
+            "sacct",
+            "--starttime=now-10minutes",
+        ]
+
+    @sanity_function
+    def validate(self):
+        """Validate output."""
+        return sn.all([sn.assert_eq(self.job.exitcode, 0), sn.assert_found(r"JobID", self.stdout)])
+
+    @performance_function("s")
+    def real_time(self):
+        """Extract runtime in seconds."""
+        return sn.extractsingle(r"real (?P<real_time>\S+)", self.stderr, "real_time", float)

--- a/checks/slurm/slurmrestd/slurmrestd.py
+++ b/checks/slurm/slurmrestd/slurmrestd.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Checks for Slurm REST API health."""
+
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+REFERENCE = {
+    "azure:login": {"real_time": (0.1, None, 0.1, "s")},
+}
+
+
+@rfm.simple_test
+class slurmrestd_api_check(rfm.RunOnlyRegressionTest):
+    """Slurm REST API health check."""
+
+    valid_systems = ["*:login"]
+    valid_prog_environs = ["builtin"]
+    reference = REFERENCE
+
+    slurmrestd_hostname = variable(str, value="localhost")
+    # v0.0.40 is current as of slurm-wlm 23.11.4.
+    slurmrestd_api_version = variable(str, value="v0.0.40")
+
+    @run_before("run")
+    def set_run_commands(self):
+        """Set job script commands."""
+        # Generate a JWT token for Slurm API access (default life 30 mins).
+        # This is exported as environment variable $SLURM_JWT.
+        # Unset any existing $SLURM_JWT as this being set to an expired or invalid token may prevent
+        # the scontrol call to request a new token from succeeding.
+        self.prerun_cmds = ["unset SLURM_JWT; export $(scontrol token)"]
+
+        # Job script uses `curl` to run API diagnostics from all valid_systems. Latency is measured
+        # using `time`.
+        self.executable = "time"
+        self.executable_opts = [
+            "-p",
+            "curl",
+            "-s",
+            "-H X-SLURM-USER-TOKEN:$SLURM_JWT",
+            f"-X GET 'http://{self.slurmrestd_hostname}:6820/slurm/{self.slurmrestd_api_version}/diag'",
+        ]
+
+    @sanity_function
+    def validate(self):
+        """Validate output."""
+        return sn.all(
+            [sn.assert_eq(self.job.exitcode, 0), sn.assert_found(r'"errors": \[\]', self.stdout)]
+        )
+
+    @performance_function("s")
+    def real_time(self):
+        """Extract runtime in seconds."""
+        return sn.extractsingle(r"real (?P<real_time>\S+)", self.stderr, "real_time", float)

--- a/scripts/azure/run_azure.sh
+++ b/scripts/azure/run_azure.sh
@@ -75,7 +75,7 @@ git clone https://github.com/charmed-hpc/charmed-hpc-benchmarks.git
 cd charmed-hpc-benchmarks
 
 # Recursively run all checks
-reframe -C config/azure_config.py -c checks -r -R -S slurmrestd_api_check.slurmrestd_hostname="$1"
+-reframe --config-file config/azure_config.py --checkpath checks --recursive --run --setvar slurmrestd_api_check.slurmrestd_hostname="$1"
 EOF
 
 echo  "Copying back test outputs..."


### PR DESCRIPTION
Adds health checks for the accounting database (`slurmdbd`) and API (`slurmrestd`).

For the `slurmdbd` check:
* `sacct --starttime=now-10minutes` is run to query recent database entries.
* The return code must be 0.
* The string `JobID` must appear in stdout.
* `sacct` latency must be less than 0.2s+10%.

For the `slurmrestd` check:
* The hostname for the API endpoint (i.e. the Juju unit running `slurmrestd`) is a ReFrame variable and must be specified when launching the test suite.
  * e.g. `reframe -S slurmrestd_api_check.slurmrestd_hostname=juju-abcd-5 [...]`
* A GET for `/slurm/v0.0.40/diag` is run using `curl` to query cluster status.
  * ReFrame variable `slurmrestd_api_version` can be used to adjust the API version from `v0.0.40` if needed.
* The return code must be 0.
* The string `"errors": []` must appear in stdout.
* `curl` latency must be less than 0.1s+10%.