### PR TITLE
feat: add CODEOWNERS file to repository

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{py,ini}]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,tf,sh,md}]
+indent_style = space
+indent_size = 2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @charmed-hpc/python-reviewers


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds a CODEOWNERS file that will automatically tag a Python reviewer when a new PR is open against this repository. While the repository is marked as primarily C++ based due to the vendoring of the GPU burn test, ReFrame and complementing tests are either in Terraform or Python.

This PR also adds a .editorconfig file for cross-editor consistency. This way there won't inconsistent spacing especially in Markdown documents or shell scripts.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Mentioned a CODEOWNERS file would be nice to have in a previous PR.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

This PR makes no functional changes to the benchmark/performance tests, and the CODEOWNERS file is a development related file for GitHub.