### PR TITLE
fix: use correct source url for mysql tf module

### DIFF
--- a/scripts/azure/main.tf
+++ b/scripts/azure/main.tf
@@ -100,8 +100,7 @@ module "nfs-share" {
 
 ## MySQL - provides backing database for the accounting node.
 module "mysql" {
-  #source = "git::https://github.com/canonical/mysql-operator//terraform"
-  source = "/home/me/repos/mysql-operator/terraform"
+  source = "git::https://github.com/canonical/mysql-operator//terraform"
 
   juju_model_name = juju_model.charmed-hpc.name
   app_name        = "mysql"


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

Noticed that the MySQL module was being imported from `/home/me` rather than from the upstream GitHub repository. This path resolution would cause `tofu init` to fail with a non-zero exit code because it could not successfully import the MySQL tf module.


#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

N/A - noticed this issue while running the benchmarks.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [x] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

No documentation changes are required because no user-facing functional changes are being introduced to the benchmarks.
