### PR TITLE
fix: remove `/en/` from ReadTheDocs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ substituting `slurmrestd_hostname=juju-50c1e0-2` with the instance ID for `slurm
 
 To learn more about the benchmarks and Charmed HPC in general, the following resources are available:
 
-* [Charmed HPC Documentation](https://canonical-charmed-hpc.readthedocs-hosted.com/en/latest)
+* [Charmed HPC Documentation](https://canonical-charmed-hpc.readthedocs-hosted.com/latest)
 * [Documentation in `scripts` subdirectories for supported clouds](./scripts)
 * [Open an issue](https://github.com/charmed-hpc/charmed-hpc-benchmarks/issues/new?title=ISSUE+TITLE&body=*Please+describe+your+issue*)
 * [Ask a question on the Charmed HPC GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)

--- a/scripts/azure/README.md
+++ b/scripts/azure/README.md
@@ -25,7 +25,7 @@ Before running the script, you will need:
   * [Juju CLI client](https://juju.is/docs/juju/install-and-manage-the-client)
   * [OpenTofu infrastructure as code tool](https://opentofu.org/docs/intro/install/)
   * [`jq` command-line JSON processor](https://jqlang.org/)
-* [Your Azure credentials added to the Juju CLI client](https://canonical-charmed-hpc.readthedocs-hosted.com/en/latest/howto/initialize-cloud-environment/) but no controller bootstrapped
+* [Your Azure credentials added to the Juju CLI client](https://canonical-charmed-hpc.readthedocs-hosted.com/latest/howto/initialize-cloud-environment/) but no controller bootstrapped
 
 ## Running
 


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have insured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

Quick fixes of links to ReadTheDocs documentation to remove the `/en/` component of the URLs and avoid unnecessary redirects.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Motivated following discussion with @AshleyCliff around cleaning up these links.

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

No changes needed to external documentation. This is just a minor README fix.
